### PR TITLE
feat: Add WebAPI format support and fix CI test issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ if warnings:
         print(f"  - {warning.message}")
 ```
 
-## WebAPI Format Support (NEW in v0.2.0)
+## WebAPI Format Support
 
-This library now supports **WebAPI camelCase format** in addition to the native Circe mixed-case format. This enables seamless integration with OHDSI WebAPI clients.
+This library supports **WebAPI camelCase format** in addition to the native Circe mixed-case format. This enables seamless integration with OHDSI WebAPI clients.
 
 ### Format Differences
 
@@ -281,34 +281,6 @@ The library provides separate validation functions for each format to ensure sea
 
 ### Validation Examples
 
-#### Database Format Validation (ALL_CAPS)
-For Circe test data and database-formatted JSON:
-
-```python
-from ohdsi_cohort_schemas import validate_db_schema, validate_db_with_warnings
-from pydantic import ValidationError
-
-# Fast schema validation - structure and types only
-try:
-    cohort = validate_db_schema(circe_json)  # ALL_CAPS format
-    print("✅ Valid schema!")
-except ValidationError as e:
-    print(f"❌ Schema errors: {e}")
-
-# Full validation with business logic checks
-result = validate_db_with_warnings(circe_json)
-if result.is_valid:
-    print("✅ Valid cohort definition!")
-    if result.warnings:
-        print("⚠️ Warnings:")
-        for warning in result.warnings:
-            print(f"  - {warning}")
-else:
-    print("❌ Validation failed:")
-    for error in result.errors:
-        print(f"  - {error}")
-```
-
 #### WebAPI Format Validation (camelCase)
 For WebAPI responses and web application JSON:
 
@@ -336,13 +308,13 @@ else:
         print(f"  - {error}")
 ```
 
-#### Legacy API (Backward Compatibility)
-The original functions are still available and work with database format:
+#### Standard Validation Functions
+The main validation functions work with the Circe mixed-case format:
 
 ```python
 from ohdsi_cohort_schemas import validate_schema_only, validate_with_warnings, validate_strict
 
-# Legacy functions (equivalent to validate_db_* functions)
+# Fast schema validation
 try:
     cohort = validate_schema_only(circe_json)
     print("✅ Valid schema!")
@@ -383,12 +355,12 @@ for issue in warnings:
     print(f"⚠️ {issue.rule}: {issue.message}")
 ```
 
-#### Legacy Validation API
+#### Direct Pydantic Validation
 ```python
 from ohdsi_cohort_schemas import CohortExpression
 from pydantic import ValidationError
 
-# Direct Pydantic validation (legacy approach)
+# Direct Pydantic validation (lowest-level approach)
 try:
     cohort = CohortExpression.model_validate(cohort_json)
     print("✅ Valid schema!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ohdsi-cohort-schemas"
-version = "0.1.0"
+version = "0.2.0"
 description = "Pydantic models for validating OHDSI/Circe cohort definition schemas"
 authors = ["Chase Sweeting <chassweeting@users.noreply.github.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "ohdsi-cohort-schemas"
-version = "0.2.0"
+version = "0.3.0"
 description = "Pydantic models for validating OHDSI/Circe cohort definition schemas"
 authors = ["Chase Sweeting <chassweeting@users.noreply.github.com>"]
 readme = "README.md"

--- a/src/ohdsi_cohort_schemas/__init__.py
+++ b/src/ohdsi_cohort_schemas/__init__.py
@@ -50,13 +50,20 @@ from .models.vocabulary import Concept
 from .validation import (
     BusinessLogicValidator,
     ValidationIssue,
+    camel_to_pascal_dict,
+    circe_to_webapi_dict,
+    pascal_to_camel_dict,
     validate_cohort_with_business_logic,
     validate_schema_only,
     validate_strict,
+    validate_webapi_schema_only,
+    validate_webapi_strict,
+    validate_webapi_with_warnings,
     validate_with_warnings,
+    webapi_to_circe_dict,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = [
     # Main models
     "CohortExpression",
@@ -73,8 +80,15 @@ __all__ = [
     # Business logic validation
     "BusinessLogicValidator",
     "ValidationIssue",
+    "camel_to_pascal_dict",
+    "circe_to_webapi_dict",
+    "pascal_to_camel_dict",
     "validate_cohort_with_business_logic",
     "validate_schema_only",
+    "validate_webapi_schema_only",
+    "validate_webapi_strict",
+    "validate_webapi_with_warnings",
     "validate_with_warnings",
     "validate_strict",
+    "webapi_to_circe_dict",
 ]

--- a/src/ohdsi_cohort_schemas/__init__.py
+++ b/src/ohdsi_cohort_schemas/__init__.py
@@ -63,7 +63,7 @@ from .validation import (
     webapi_to_circe_dict,
 )
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 __all__ = [
     # Main models
     "CohortExpression",

--- a/tests/test_all_circe_data.py
+++ b/tests/test_all_circe_data.py
@@ -105,10 +105,7 @@ def test_all_circe_data_validates_successfully():
         if len(failures) > 5:
             failure_details += f"\n  ... and {len(failures) - 5} more failures"
 
-        pytest.fail(
-            f"{len(failures)} out of {total_cohort_expressions} cohort expressions failed validation:\n"
-            f"{failure_details}"
-        )
+        pytest.fail(f"{len(failures)} out of {total_cohort_expressions} cohort expressions failed validation:\n" f"{failure_details}")
 
     # Ensure we actually tested some cohort expressions
     assert total_cohort_expressions > 0, "No cohort expressions found to validate"

--- a/tests/test_all_circe_data.py
+++ b/tests/test_all_circe_data.py
@@ -7,9 +7,9 @@ to ensure maximum compatibility with OHDSI standards.
 """
 
 import json
-import pytest
 from pathlib import Path
 
+import pytest
 from ohdsi_cohort_schemas.models.cohort import CohortExpression
 from pydantic import ValidationError
 
@@ -53,7 +53,7 @@ def validate_file(json_path: Path) -> tuple[bool, str]:
 
 def test_all_circe_data_validates_successfully():
     """Test that all Circe test data validates successfully with our schema."""
-    
+
     # Find all JSON files in test resources
     test_resources = Path(__file__).parent / "resources"
     json_files = list(test_resources.rglob("*.json"))
@@ -84,17 +84,17 @@ def test_all_circe_data_validates_successfully():
 
     # Collect all failures for detailed reporting
     failures = []
-    for category, category_results in results.items():
+    for _, category_results in results.items():
         for file_path, success, message in category_results:
             if not success and not message.startswith("SKIPPED"):
                 failures.append((file_path.name, message))
 
     # Print summary for debugging
-    print(f"\nCirce validation summary:")
+    print("\nCirce validation summary:")
     print(f"  Total JSON files: {len(json_files)}")
     print(f"  Cohort expressions: {total_cohort_expressions}")
     print(f"  Successfully validated: {successful_validations}")
-    
+
     if total_cohort_expressions > 0:
         success_rate = (successful_validations / total_cohort_expressions) * 100
         print(f"  Success rate: {success_rate:.1f}%")
@@ -104,7 +104,7 @@ def test_all_circe_data_validates_successfully():
         failure_details = "\n".join([f"  - {name}: {msg[:100]}..." for name, msg in failures[:5]])
         if len(failures) > 5:
             failure_details += f"\n  ... and {len(failures) - 5} more failures"
-        
+
         pytest.fail(
             f"{len(failures)} out of {total_cohort_expressions} cohort expressions failed validation:\n"
             f"{failure_details}"
@@ -112,13 +112,13 @@ def test_all_circe_data_validates_successfully():
 
     # Ensure we actually tested some cohort expressions
     assert total_cohort_expressions > 0, "No cohort expressions found to validate"
-    assert successful_validations == total_cohort_expressions, f"Not all cohort expressions validated successfully"
+    assert successful_validations == total_cohort_expressions, "Not all cohort expressions validated successfully"
 
 
 if __name__ == "__main__":
     """Run as a standalone script for detailed reporting."""
     import sys
-    
+
     # Find all JSON files in test resources
     test_resources = Path(__file__).parent / "resources"
     json_files = list(test_resources.rglob("*.json"))

--- a/tests/test_webapi_conversion.py
+++ b/tests/test_webapi_conversion.py
@@ -1,0 +1,264 @@
+"""
+Test WebAPI format conversion and validation functions.
+"""
+
+import json
+import pytest
+from pathlib import Path
+
+from ohdsi_cohort_schemas import (
+    webapi_to_circe_dict,
+    circe_to_webapi_dict,
+    validate_webapi_schema_only,
+    validate_webapi_with_warnings,
+    validate_webapi_strict,
+    validate_schema_only,
+)
+from ohdsi_cohort_schemas.validation import WEBAPI_TO_CIRCE_FIELD_MAP, CIRCE_TO_WEBAPI_FIELD_MAP
+
+
+def test_field_mapping_coverage():
+    """Test that field mappings are bidirectional."""
+    # Check that every WebAPI field maps to a Circe field
+    for webapi_field, circe_field in WEBAPI_TO_CIRCE_FIELD_MAP.items():
+        assert webapi_field and circe_field, f"Empty field mapping: {webapi_field} -> {circe_field}"
+    
+    # Check that every Circe field maps back to a WebAPI field
+    for circe_field, webapi_field in CIRCE_TO_WEBAPI_FIELD_MAP.items():
+        assert circe_field and webapi_field, f"Empty reverse mapping: {circe_field} -> {webapi_field}"
+
+
+def test_key_mapping_examples():
+    """Test specific key mappings."""
+    test_cases = [
+        ("conceptSets", "ConceptSets"),
+        ("primaryCriteria", "PrimaryCriteria"),
+        ("conceptId", "CONCEPT_ID"),
+        ("conceptName", "CONCEPT_NAME"),
+        ("includeDescendants", "includeDescendants"),  # stays same
+        ("id", "id"),  # stays same
+        ("codesetId", "CodesetId"),
+        ("drugCodesetId", "DrugCodesetId"),
+    ]
+    
+    for webapi, expected_circe in test_cases:
+        result = WEBAPI_TO_CIRCE_FIELD_MAP.get(webapi, webapi)
+        assert result == expected_circe, f"WebAPI->Circe: {webapi} -> {result} (expected: {expected_circe})"
+        
+        reverse = CIRCE_TO_WEBAPI_FIELD_MAP.get(expected_circe, expected_circe)
+        assert reverse == webapi, f"Circe->WebAPI: {expected_circe} -> {reverse} (expected: {webapi})"
+
+
+def test_dict_conversion_simple():
+    """Test dictionary conversion with simple data."""
+    webapi_data = {
+        "conceptSets": [
+            {
+                "id": 1,
+                "name": "Test Concept Set",
+                "expression": {
+                    "items": [
+                        {
+                            "concept": {
+                                "conceptId": 123,
+                                "conceptName": "Test Concept",
+                                "standardConcept": "S",
+                                "invalidReason": "V",
+                                "conceptCode": "TEST",
+                                "domainId": "Condition",
+                                "vocabularyId": "SNOMED",
+                                "conceptClassId": "Clinical Finding"
+                            },
+                            "includeDescendants": True,
+                            "isExcluded": False,
+                            "includeMapped": False
+                        }
+                    ]
+                }
+            }
+        ],
+        "primaryCriteria": {
+            "criteriaList": [
+                {
+                    "conditionOccurrence": {
+                        "codesetId": 1
+                    }
+                }
+            ],
+            "observationWindow": {
+                "priorDays": 0,
+                "postDays": 0
+            },
+            "primaryCriteriaLimit": {
+                "type": "First"
+            }
+        },
+        "qualifiedLimit": {
+            "type": "First"
+        },
+        "expressionLimit": {
+            "type": "First"
+        },
+        "inclusionRules": [],
+        "censoringCriteria": []
+    }
+    
+    # Convert to Circe format
+    circe_data = webapi_to_circe_dict(webapi_data)
+    
+    # Check key transformations
+    assert "ConceptSets" in circe_data
+    assert "PrimaryCriteria" in circe_data
+    assert circe_data["ConceptSets"][0]["expression"]["items"][0]["concept"]["CONCEPT_ID"] == 123
+    assert circe_data["ConceptSets"][0]["expression"]["items"][0]["concept"]["CONCEPT_NAME"] == "Test Concept"
+    assert circe_data["PrimaryCriteria"]["CriteriaList"][0]["ConditionOccurrence"]["CodesetId"] == 1
+    
+    # Convert back to WebAPI format
+    webapi_back = circe_to_webapi_dict(circe_data)
+    
+    # Check round-trip conversion
+    assert webapi_back["conceptSets"][0]["id"] == webapi_data["conceptSets"][0]["id"]
+    assert webapi_back["conceptSets"][0]["expression"]["items"][0]["concept"]["conceptId"] == 123
+    assert webapi_back["primaryCriteria"]["criteriaList"][0]["conditionOccurrence"]["codesetId"] == 1
+
+
+def test_webapi_validation_functions():
+    """Test WebAPI validation functions."""
+    webapi_data = {
+        "conceptSets": [
+            {
+                "id": 1,
+                "name": "Test Concept Set",
+                "expression": {
+                    "items": [
+                        {
+                            "concept": {
+                                "conceptId": 123,
+                                "conceptName": "Test Concept",
+                                "standardConcept": "S",
+                                "invalidReason": "V",
+                                "conceptCode": "TEST",
+                                "domainId": "Condition",
+                                "vocabularyId": "SNOMED",
+                                "conceptClassId": "Clinical Finding"
+                            },
+                            "includeDescendants": True
+                        }
+                    ]
+                }
+            }
+        ],
+        "primaryCriteria": {
+            "criteriaList": [
+                {
+                    "conditionOccurrence": {
+                        "codesetId": 1
+                    }
+                }
+            ],
+            "observationWindow": {
+                "priorDays": 0,
+                "postDays": 0
+            },
+            "primaryCriteriaLimit": {
+                "type": "First"
+            }
+        },
+        "qualifiedLimit": {
+            "type": "First"
+        },
+        "expressionLimit": {
+            "type": "First"
+        },
+        "inclusionRules": [],
+        "censoringCriteria": []
+    }
+    
+    # Test schema-only validation
+    cohort = validate_webapi_schema_only(webapi_data)
+    assert cohort is not None
+    assert len(cohort.concept_sets) == 1
+    assert cohort.concept_sets[0].id == 1
+    
+    # Test validation with warnings
+    cohort, warnings = validate_webapi_with_warnings(webapi_data)
+    assert cohort is not None
+    # There should be no warnings for this simple valid cohort
+    assert len(warnings) == 0
+    
+    # Test strict validation
+    cohort = validate_webapi_strict(webapi_data)
+    assert cohort is not None
+
+
+def test_real_circe_file_conversion():
+    """Test conversion with a real Circe JSON file."""
+    circe_file = Path(__file__).parent / "resources" / "checkers" / "eventsProgressionCheckCorrect.json"
+    
+    if not circe_file.exists():
+        pytest.skip("Test file not found")
+    
+    with open(circe_file) as f:
+        circe_data = json.load(f)
+    
+    # Validate original Circe format
+    cohort_circe = validate_schema_only(circe_data)
+    assert cohort_circe is not None
+    
+    # Convert to WebAPI format
+    webapi_data = circe_to_webapi_dict(circe_data)
+    
+    # Validate WebAPI format
+    cohort_webapi = validate_webapi_schema_only(webapi_data)
+    assert cohort_webapi is not None
+    
+    # Convert back to Circe format
+    circe_back = webapi_to_circe_dict(webapi_data)
+    
+    # Validate round-trip
+    cohort_roundtrip = validate_schema_only(circe_back)
+    assert cohort_roundtrip is not None
+    
+    # Check data integrity
+    assert len(circe_data.get("ConceptSets", [])) == len(circe_back.get("ConceptSets", []))
+    if circe_data.get("ConceptSets"):
+        assert circe_data["ConceptSets"][0]["id"] == circe_back["ConceptSets"][0]["id"]
+
+
+def test_unknown_fields_preserved():
+    """Test that unknown fields are preserved during conversion."""
+    webapi_data = {
+        "conceptSets": [],
+        "primaryCriteria": {
+            "criteriaList": [],
+            "observationWindow": {"priorDays": 0, "postDays": 0},
+            "primaryCriteriaLimit": {"type": "First"}
+        },
+        "qualifiedLimit": {"type": "First"},
+        "expressionLimit": {"type": "First"},
+        "inclusionRules": [],
+        "censoringCriteria": [],
+        "unknownField": "should be preserved",
+        "nestedUnknown": {
+            "someField": "also preserved",
+            "deepNested": {
+                "evenDeeper": "still here"
+            }
+        }
+    }
+    
+    # Convert to Circe format
+    circe_data = webapi_to_circe_dict(webapi_data)
+    
+    # Unknown fields should be preserved
+    assert circe_data["unknownField"] == "should be preserved"
+    assert circe_data["nestedUnknown"]["someField"] == "also preserved"
+    assert circe_data["nestedUnknown"]["deepNested"]["evenDeeper"] == "still here"
+    
+    # Convert back
+    webapi_back = circe_to_webapi_dict(circe_data)
+    
+    # Unknown fields should still be there
+    assert webapi_back["unknownField"] == "should be preserved"
+    assert webapi_back["nestedUnknown"]["someField"] == "also preserved"
+    assert webapi_back["nestedUnknown"]["deepNested"]["evenDeeper"] == "still here"

--- a/tests/test_webapi_conversion.py
+++ b/tests/test_webapi_conversion.py
@@ -67,40 +67,25 @@ def test_dict_conversion_simple():
                                 "conceptCode": "TEST",
                                 "domainId": "Condition",
                                 "vocabularyId": "SNOMED",
-                                "conceptClassId": "Clinical Finding"
+                                "conceptClassId": "Clinical Finding",
                             },
                             "includeDescendants": True,
                             "isExcluded": False,
-                            "includeMapped": False
+                            "includeMapped": False,
                         }
                     ]
-                }
+                },
             }
         ],
         "primaryCriteria": {
-            "criteriaList": [
-                {
-                    "conditionOccurrence": {
-                        "codesetId": 1
-                    }
-                }
-            ],
-            "observationWindow": {
-                "priorDays": 0,
-                "postDays": 0
-            },
-            "primaryCriteriaLimit": {
-                "type": "First"
-            }
+            "criteriaList": [{"conditionOccurrence": {"codesetId": 1}}],
+            "observationWindow": {"priorDays": 0, "postDays": 0},
+            "primaryCriteriaLimit": {"type": "First"},
         },
-        "qualifiedLimit": {
-            "type": "First"
-        },
-        "expressionLimit": {
-            "type": "First"
-        },
+        "qualifiedLimit": {"type": "First"},
+        "expressionLimit": {"type": "First"},
         "inclusionRules": [],
-        "censoringCriteria": []
+        "censoringCriteria": [],
     }
 
     # Convert to Circe format
@@ -140,38 +125,23 @@ def test_webapi_validation_functions():
                                 "conceptCode": "TEST",
                                 "domainId": "Condition",
                                 "vocabularyId": "SNOMED",
-                                "conceptClassId": "Clinical Finding"
+                                "conceptClassId": "Clinical Finding",
                             },
-                            "includeDescendants": True
+                            "includeDescendants": True,
                         }
                     ]
-                }
+                },
             }
         ],
         "primaryCriteria": {
-            "criteriaList": [
-                {
-                    "conditionOccurrence": {
-                        "codesetId": 1
-                    }
-                }
-            ],
-            "observationWindow": {
-                "priorDays": 0,
-                "postDays": 0
-            },
-            "primaryCriteriaLimit": {
-                "type": "First"
-            }
+            "criteriaList": [{"conditionOccurrence": {"codesetId": 1}}],
+            "observationWindow": {"priorDays": 0, "postDays": 0},
+            "primaryCriteriaLimit": {"type": "First"},
         },
-        "qualifiedLimit": {
-            "type": "First"
-        },
-        "expressionLimit": {
-            "type": "First"
-        },
+        "qualifiedLimit": {"type": "First"},
+        "expressionLimit": {"type": "First"},
         "inclusionRules": [],
-        "censoringCriteria": []
+        "censoringCriteria": [],
     }
 
     # Test schema-only validation
@@ -232,19 +202,14 @@ def test_unknown_fields_preserved():
         "primaryCriteria": {
             "criteriaList": [],
             "observationWindow": {"priorDays": 0, "postDays": 0},
-            "primaryCriteriaLimit": {"type": "First"}
+            "primaryCriteriaLimit": {"type": "First"},
         },
         "qualifiedLimit": {"type": "First"},
         "expressionLimit": {"type": "First"},
         "inclusionRules": [],
         "censoringCriteria": [],
         "unknownField": "should be preserved",
-        "nestedUnknown": {
-            "someField": "also preserved",
-            "deepNested": {
-                "evenDeeper": "still here"
-            }
-        }
+        "nestedUnknown": {"someField": "also preserved", "deepNested": {"evenDeeper": "still here"}},
     }
 
     # Convert to Circe format

--- a/tests/test_webapi_conversion.py
+++ b/tests/test_webapi_conversion.py
@@ -3,18 +3,18 @@ Test WebAPI format conversion and validation functions.
 """
 
 import json
-import pytest
 from pathlib import Path
 
+import pytest
 from ohdsi_cohort_schemas import (
-    webapi_to_circe_dict,
     circe_to_webapi_dict,
-    validate_webapi_schema_only,
-    validate_webapi_with_warnings,
-    validate_webapi_strict,
     validate_schema_only,
+    validate_webapi_schema_only,
+    validate_webapi_strict,
+    validate_webapi_with_warnings,
+    webapi_to_circe_dict,
 )
-from ohdsi_cohort_schemas.validation import WEBAPI_TO_CIRCE_FIELD_MAP, CIRCE_TO_WEBAPI_FIELD_MAP
+from ohdsi_cohort_schemas.validation import CIRCE_TO_WEBAPI_FIELD_MAP, WEBAPI_TO_CIRCE_FIELD_MAP
 
 
 def test_field_mapping_coverage():
@@ -22,7 +22,7 @@ def test_field_mapping_coverage():
     # Check that every WebAPI field maps to a Circe field
     for webapi_field, circe_field in WEBAPI_TO_CIRCE_FIELD_MAP.items():
         assert webapi_field and circe_field, f"Empty field mapping: {webapi_field} -> {circe_field}"
-    
+
     # Check that every Circe field maps back to a WebAPI field
     for circe_field, webapi_field in CIRCE_TO_WEBAPI_FIELD_MAP.items():
         assert circe_field and webapi_field, f"Empty reverse mapping: {circe_field} -> {webapi_field}"
@@ -40,11 +40,11 @@ def test_key_mapping_examples():
         ("codesetId", "CodesetId"),
         ("drugCodesetId", "DrugCodesetId"),
     ]
-    
+
     for webapi, expected_circe in test_cases:
         result = WEBAPI_TO_CIRCE_FIELD_MAP.get(webapi, webapi)
         assert result == expected_circe, f"WebAPI->Circe: {webapi} -> {result} (expected: {expected_circe})"
-        
+
         reverse = CIRCE_TO_WEBAPI_FIELD_MAP.get(expected_circe, expected_circe)
         assert reverse == webapi, f"Circe->WebAPI: {expected_circe} -> {reverse} (expected: {webapi})"
 
@@ -102,20 +102,20 @@ def test_dict_conversion_simple():
         "inclusionRules": [],
         "censoringCriteria": []
     }
-    
+
     # Convert to Circe format
     circe_data = webapi_to_circe_dict(webapi_data)
-    
+
     # Check key transformations
     assert "ConceptSets" in circe_data
     assert "PrimaryCriteria" in circe_data
     assert circe_data["ConceptSets"][0]["expression"]["items"][0]["concept"]["CONCEPT_ID"] == 123
     assert circe_data["ConceptSets"][0]["expression"]["items"][0]["concept"]["CONCEPT_NAME"] == "Test Concept"
     assert circe_data["PrimaryCriteria"]["CriteriaList"][0]["ConditionOccurrence"]["CodesetId"] == 1
-    
+
     # Convert back to WebAPI format
     webapi_back = circe_to_webapi_dict(circe_data)
-    
+
     # Check round-trip conversion
     assert webapi_back["conceptSets"][0]["id"] == webapi_data["conceptSets"][0]["id"]
     assert webapi_back["conceptSets"][0]["expression"]["items"][0]["concept"]["conceptId"] == 123
@@ -173,19 +173,19 @@ def test_webapi_validation_functions():
         "inclusionRules": [],
         "censoringCriteria": []
     }
-    
+
     # Test schema-only validation
     cohort = validate_webapi_schema_only(webapi_data)
     assert cohort is not None
     assert len(cohort.concept_sets) == 1
     assert cohort.concept_sets[0].id == 1
-    
+
     # Test validation with warnings
     cohort, warnings = validate_webapi_with_warnings(webapi_data)
     assert cohort is not None
     # There should be no warnings for this simple valid cohort
     assert len(warnings) == 0
-    
+
     # Test strict validation
     cohort = validate_webapi_strict(webapi_data)
     assert cohort is not None
@@ -194,31 +194,31 @@ def test_webapi_validation_functions():
 def test_real_circe_file_conversion():
     """Test conversion with a real Circe JSON file."""
     circe_file = Path(__file__).parent / "resources" / "checkers" / "eventsProgressionCheckCorrect.json"
-    
+
     if not circe_file.exists():
         pytest.skip("Test file not found")
-    
+
     with open(circe_file) as f:
         circe_data = json.load(f)
-    
+
     # Validate original Circe format
     cohort_circe = validate_schema_only(circe_data)
     assert cohort_circe is not None
-    
+
     # Convert to WebAPI format
     webapi_data = circe_to_webapi_dict(circe_data)
-    
+
     # Validate WebAPI format
     cohort_webapi = validate_webapi_schema_only(webapi_data)
     assert cohort_webapi is not None
-    
+
     # Convert back to Circe format
     circe_back = webapi_to_circe_dict(webapi_data)
-    
+
     # Validate round-trip
     cohort_roundtrip = validate_schema_only(circe_back)
     assert cohort_roundtrip is not None
-    
+
     # Check data integrity
     assert len(circe_data.get("ConceptSets", [])) == len(circe_back.get("ConceptSets", []))
     if circe_data.get("ConceptSets"):
@@ -246,18 +246,18 @@ def test_unknown_fields_preserved():
             }
         }
     }
-    
+
     # Convert to Circe format
     circe_data = webapi_to_circe_dict(webapi_data)
-    
+
     # Unknown fields should be preserved
     assert circe_data["unknownField"] == "should be preserved"
     assert circe_data["nestedUnknown"]["someField"] == "also preserved"
     assert circe_data["nestedUnknown"]["deepNested"]["evenDeeper"] == "still here"
-    
+
     # Convert back
     webapi_back = circe_to_webapi_dict(circe_data)
-    
+
     # Unknown fields should still be there
     assert webapi_back["unknownField"] == "should be preserved"
     assert webapi_back["nestedUnknown"]["someField"] == "also preserved"


### PR DESCRIPTION
- Add comprehensive WebAPI (camelCase) to Circe (mixed case) format conversion
- Implement field mapping system handling PascalCase, camelCase, and ALL_CAPS
- Add validate_webapi_schema_only(), validate_webapi_with_warnings(), validate_webapi_strict()
- Add webapi_to_circe_dict() and circe_to_webapi_dict() conversion functions
- Fix test_all_circe_data.py to work as proper pytest test (resolves CI error code 5)
- Add comprehensive test suite for WebAPI conversion features
- Update README with WebAPI format documentation and examples
- Bump version to 0.2.0

This enables seamless integration with OHDSI WebAPI clients while maintaining 100% compatibility with existing Circe format validation.